### PR TITLE
Count failures and return that as the exit code.

### DIFF
--- a/lib/uspec/stats.rb
+++ b/lib/uspec/stats.rb
@@ -14,7 +14,8 @@ module Uspec
       end
 
       def exit_code
-        results.all?{|result| result == true} ? 0 : 255
+        failures = results.count{|result| !result }
+        failures > 255 ? 255 : failures
       end
     end
   end

--- a/uspec/uspec_spec.rb
+++ b/uspec/uspec_spec.rb
@@ -48,3 +48,15 @@ end
 spec 'should not define DSL methods on arbitrary objects' do
   !(Array.respond_to? :spec)
 end
+
+spec 'returns the number of failures' do
+  capture do
+    50.times do
+      spec 'fail' do
+        false
+      end
+    end
+  end
+
+  $?.exitstatus == 50 || $?
+end

--- a/uspec/uspec_spec.rb
+++ b/uspec/uspec_spec.rb
@@ -49,7 +49,7 @@ spec 'should not define DSL methods on arbitrary objects' do
   !(Array.respond_to? :spec)
 end
 
-spec 'returns the number of failures' do
+spec 'exit code is the number of failures' do
   capture do
     50.times do
       spec 'fail' do
@@ -59,4 +59,16 @@ spec 'returns the number of failures' do
   end
 
   $?.exitstatus == 50 || $?
+end
+
+spec 'if more than 255 failures, exit status is 255' do
+  capture do
+    500.times do
+      spec 'fail' do
+        false
+      end
+    end
+  end
+
+  $?.exitstatus == 255 || $?
 end


### PR DESCRIPTION
example:

``` ruby
# count_fails.rb
50.times do
  spec 'fail' do
    false
  end
end
```

output:

```
$ uspec count_fails.rb
....
$ echo $?
50
```
