### PR TITLE
No at_exit, no global state

### DIFF
--- a/bin/uspec
+++ b/bin/uspec
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
 
 require_relative '../lib/uspec/cli'
-Uspec::CLI.invoke ARGV
+Uspec::CLI.new(ARGV).invoke

--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -8,7 +8,10 @@ module Uspec
     exit 2
   end
 
+  # this method used to be how we injected the spec method
   def self.extended object
-    object.extend Uspec::DSL
+    #unless object.respond_to? :spec
+    #  object.extend Uspec::DSL
+    #end
   end
 end

--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -12,19 +12,3 @@ module Uspec
     object.extend Uspec::DSL
   end
 end
-
-at_exit do
-  failures = Uspec::Stats.exit_code
-  status = $!.respond_to?(:status) ? $!.status : 0
-  errors = $!.respond_to?(:cause) && $!.cause ? 1 : 0
-  code = [failures, status, errors].max
-  puts [
-    "test summary: ",
-    Uspec::Terminal.green("#{Uspec::Stats.successes} successful"),
-    ", ",
-    Uspec::Terminal.red("#{Uspec::Stats.failures} failed"),
-    ", ",
-    Uspec::Terminal.yellow("#{Uspec::Stats.pending.size} pending")
-  ].join
-  exit code
-end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -16,6 +16,8 @@ class Uspec::CLI
     def invoke args
       if (args & %w[-h --help -? /? -v --version]).empty? then
         run_specs args
+        puts Uspec::Stats.summary
+        exit Uspec::Stats.exit_code
       else
         usage
       end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -8,19 +8,26 @@ class Uspec::CLI
       warn "usage: #{File.basename $0} [<file_or_path>...]"
     end
 
+    def setup
+      @stats = Uspec::Stats.new
+    end
+
     def run_specs paths
       uspec_cli = self.new paths
       uspec_cli.run_paths
     end
 
     def invoke args
-      if (args & %w[-h --help -? /? -v --version]).empty? then
-        run_specs args
-        puts Uspec::Stats.summary
-        exit Uspec::Stats.exit_code
-      else
-        usage
-      end
+      usage unless (args & %w[-h --help -? /? -v --version]).empty?
+
+      setup
+      run_specs args
+      puts @stats.summary
+      exit @stats.exit_code
+    end
+
+    def stats
+      @stats
     end
   end
 
@@ -76,7 +83,7 @@ class Uspec::CLI
     MSG
     puts
     warn message
-    Uspec::Stats.results << Uspec::Result.new(message, error, caller)
+    self.class.stats.failure << Uspec::Result.new(message, error, caller)
   end
 
 end

--- a/lib/uspec/dsl.rb
+++ b/lib/uspec/dsl.rb
@@ -1,8 +1,19 @@
 require_relative "result"
 
 module Uspec
-  module DSL
-    module_function
+  class DSL
+    def initialize cli
+      @__uspec_cli = cli
+    end
+
+    def __uspec_cli
+      @__uspec_cli
+    end
+
+    def __uspec_stats
+      @__uspec_cli.stats
+    end
+
     def spec description
       print ' -- ', description
 
@@ -20,11 +31,11 @@ module Uspec
       end
 
       if result.success?
-        Uspec::CLI.stats.success << result
+        __uspec_stats.success << result
       elsif result.pending?
-        Uspec::CLI.stats.pending << result
+        stats.pending << result
       else
-        Uspec::CLI.stats.failure << result
+        __uspec_stats.failure << result
       end
 
       print ': ', result.pretty, "\n"
@@ -38,7 +49,7 @@ module Uspec
       MSG
       puts
       warn message
-      Uspec::Stats.failure << Uspec::Result.new(message, error, caller)
+      __uspec_stats.failure << Uspec::Result.new(message, error, caller)
     end
   end
 end

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -18,6 +18,8 @@ module Uspec
         green raw
       elsif raw == false then
         red raw
+      elsif pending? then
+        yellow 'pending'
       elsif Exception === raw then
         [
           red('Exception'), vspace,
@@ -84,6 +86,22 @@ module Uspec
 
 \t#{error.backtrace.join "\n\t"}
       MSG
+    end
+
+    def success?
+      raw == true
+    end
+
+    def failure?
+      raw != true && !@pending
+    end
+
+    def pending?
+      !!@pending
+    end
+
+    def pending!
+      @pending = true
     end
 
     def inspect

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -55,9 +55,9 @@ module Uspec
     # Attempts to inspect an object
     def inspector
       if String === raw && raw.include?(?\n) then
-        # if object is a multiline string, display it escaped and unescaped
+        # if object is a multiline string, display it unescaped
         [
-          handler.inspector!, vspace,
+          vspace,
           hspace, yellow('"""'), newline,
           raw, normal, newline,
           hspace, yellow('"""')

--- a/lib/uspec/stats.rb
+++ b/lib/uspec/stats.rb
@@ -1,53 +1,40 @@
 module Uspec
   class Stats
-    class << self
-      def results?
-        !results.empty?
-      end
+    def initialize
+      clear_results!
+    end
+    attr :success, :failure, :pending
 
-      def results
-        @results || clear_results!
-      end
+    def clear_results!
+      @success = Array.new
+      @failure = Array.new
+      @pending = Array.new
+    end
 
-      def clear_results!
-        @pending = Array.new
-        @results = Array.new
-      end
+    def exit_code
+      failure.size > 255 ? 255 : failure.size
+    end
 
-      def exit_code
-        failures > 255 ? 255 : failures
-      end
-
-      def failures
-        results.count{|result| result.raw != true }
-      end
-
-      def successes
-        # checking for truthy isn't good enough, it must be exactly true!
-        results.count{|result| result.raw == true }
-      end
-
-      def pending
-        @pending || clear_results!
-      end
-
-      def inspect
-        <<-INFO
+    def inspect
+      <<-INFO
         #{super} Failures: #{exit_code}
         #{results.map{|r| r.inspect}.join "\n\t" }
-        INFO
-      end
+      INFO
+    end
 
-      def summary
-        [
-          "test summary: ",
-          Uspec::Terminal.green("#{Uspec::Stats.successes} successful"),
-          ", ",
-          Uspec::Terminal.red("#{Uspec::Stats.failures} failed"),
-          ", ",
-          Uspec::Terminal.yellow("#{Uspec::Stats.pending.size} pending")
-        ].join
-      end
+    def results
+      @success + @failure + @pending
+    end
+
+    def summary
+      [
+        "test summary: ",
+        Uspec::Terminal.green("#{@success.size} successful"),
+        ", ",
+        Uspec::Terminal.red("#{@failure.size} failed"),
+        ", ",
+        Uspec::Terminal.yellow("#{@pending.size} pending")
+      ].join
     end
   end
 end

--- a/lib/uspec/stats.rb
+++ b/lib/uspec/stats.rb
@@ -11,10 +11,6 @@ module Uspec
       @pending = Array.new
     end
 
-    def exit_code
-      failure.size > 255 ? 255 : failure.size
-    end
-
     def inspect
       <<-INFO
         #{super} Failures: #{exit_code}

--- a/lib/uspec/stats.rb
+++ b/lib/uspec/stats.rb
@@ -37,6 +37,17 @@ module Uspec
         #{results.map{|r| r.inspect}.join "\n\t" }
         INFO
       end
+
+      def summary
+        [
+          "test summary: ",
+          Uspec::Terminal.green("#{Uspec::Stats.successes} successful"),
+          ", ",
+          Uspec::Terminal.red("#{Uspec::Stats.failures} failed"),
+          ", ",
+          Uspec::Terminal.yellow("#{Uspec::Stats.pending.size} pending")
+        ].join
+      end
     end
   end
 end

--- a/lib/uspec/version.rb
+++ b/lib/uspec/version.rb
@@ -1,3 +1,3 @@
 module Uspec
-  VERSION = '0.3.0'
+  VERSION = '1.0.0'
 end

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -12,7 +12,7 @@ end
 spec 'runs a path of specs' do
   output = capture do
     path = Pathname.new(__FILE__).parent.parent.join('example_specs').to_s
-    Uspec::CLI.run_specs Array(path)
+    Uspec::CLI.new(Array(path)).run_specs
   end
 
   output.include?('I love passing tests') || output
@@ -21,7 +21,7 @@ end
 spec 'runs an individual spec' do
   output = capture do
     path =  Pathname.new(__FILE__).parent.parent.join('example_specs', 'example_spec.rb').to_s
-    Uspec::CLI.run_specs Array(path)
+    Uspec::CLI.new(Array(path)).run_specs
   end
 
   output.include?('I love passing tests') || output

--- a/uspec/uspec_spec.rb
+++ b/uspec/uspec_spec.rb
@@ -45,7 +45,7 @@ end
 spec 'exit code is the number of failures' do
   expected = 50
   output = capture do
-    Uspec::CLI.stats.clear_results! # because we're forking, we will have a copy of the current results
+    __uspec_stats.clear_results! # because we're forking, we will have a copy of the current results
 
     expected.times do |count|
       spec "fail ##{count + 1}" do
@@ -53,7 +53,7 @@ spec 'exit code is the number of failures' do
       end
     end
 
-    exit Uspec::CLI.stats.exit_code
+    exit __uspec_cli.exit_code
   end
   actual = $?.exitstatus
 
@@ -62,7 +62,7 @@ end
 
 spec 'if more than 255 failures, exit status is 255' do
   capture do
-    Uspec::CLI.stats.clear_results! # because we're forking, we will have a copy of the current results
+    __uspec_stats.clear_results! # because we're forking, we will have a copy of the current results
 
     500.times do
       spec 'fail' do
@@ -70,7 +70,7 @@ spec 'if more than 255 failures, exit status is 255' do
       end
     end
 
-    exit Uspec::CLI.stats.exit_code
+    exit __uspec_cli.exit_code
   end
 
   $?.exitstatus == 255 || $?

--- a/uspec/uspec_spec.rb
+++ b/uspec/uspec_spec.rb
@@ -45,7 +45,7 @@ end
 spec 'exit code is the number of failures' do
   expected = 50
   output = capture do
-    Uspec::Stats.clear_results! # because we're forking, we will have a copy of the current results
+    Uspec::CLI.stats.clear_results! # because we're forking, we will have a copy of the current results
 
     expected.times do |count|
       spec "fail ##{count + 1}" do
@@ -53,7 +53,7 @@ spec 'exit code is the number of failures' do
       end
     end
 
-    puts(Uspec::Stats.inspect) unless Uspec::Stats.exit_code == expected
+    exit Uspec::CLI.stats.exit_code
   end
   actual = $?.exitstatus
 
@@ -62,13 +62,15 @@ end
 
 spec 'if more than 255 failures, exit status is 255' do
   capture do
-    Uspec::Stats.clear_results! # because we're forking, we will have a copy of the current results
+    Uspec::CLI.stats.clear_results! # because we're forking, we will have a copy of the current results
 
     500.times do
       spec 'fail' do
         false
       end
     end
+
+    exit Uspec::CLI.stats.exit_code
   end
 
   $?.exitstatus == 255 || $?


### PR DESCRIPTION
This removes the `at_exit` callback as well as removing all global state. 

Should anyone notice that `extend Uspec` no longer works for them, please remove it and use the `uspec` commandline tool instead.