### PR TITLE
Refactor DSL into Harness and Define objects

### DIFF
--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -1,5 +1,5 @@
 require_relative 'uspec/version'
-require_relative 'uspec/dsl'
+require_relative 'uspec/harness'
 require_relative 'uspec/stats'
 
 module Uspec

--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -1,5 +1,6 @@
 require_relative 'uspec/version'
 require_relative 'uspec/harness'
+require_relative 'uspec/define'
 require_relative 'uspec/stats'
 
 module Uspec

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -74,7 +74,7 @@ class Uspec::CLI
       end
     elsif path.exist? then
       puts "#{path.basename path.extname}:"
-      dsl.instance_eval(path.read, path.to_s)
+      Uspec::Spec.new(dsl, self).instance_eval(path.read, path.to_s)
     else
       warn "path not found: #{path}"
     end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -74,8 +74,7 @@ class Uspec::CLI
       end
     elsif path.exist? then
       puts "#{path.basename path.extname}:"
-      #Uspec::Spec.new(harness, self).instance_eval(path.read, path.to_s)
-      harness.instance_eval(path.read, path.to_s)
+      harness.define.instance_eval(path.read, path.to_s)
     else
       warn "path not found: #{path}"
     end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -103,7 +103,7 @@ class Uspec::CLI
     warn message
     stats.failure << Uspec::Result.new(message, error, caller)
 
-    harness.__uspec_cli.handle_interrupt! error
+    handle_interrupt! error
   end
 
 end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -8,9 +8,9 @@ class Uspec::CLI
     @paths = args
     @pwd = Pathname.pwd.freeze
     @stats = Uspec::Stats.new
-    @dsl = Uspec::DSL.new self
+    @harness = Uspec::Harness.new self
   end
-  attr :stats, :dsl
+  attr :stats, :harness
 
   def usage
     warn "uspec v#{::Uspec::VERSION} - minimalistic ruby testing framework"
@@ -74,7 +74,8 @@ class Uspec::CLI
       end
     elsif path.exist? then
       puts "#{path.basename path.extname}:"
-      Uspec::Spec.new(dsl, self).instance_eval(path.read, path.to_s)
+      #Uspec::Spec.new(harness, self).instance_eval(path.read, path.to_s)
+      harness.instance_eval(path.read, path.to_s)
     else
       warn "path not found: #{path}"
     end
@@ -103,7 +104,7 @@ class Uspec::CLI
     warn message
     stats.failure << Uspec::Result.new(message, error, caller)
 
-    dsl.__uspec_cli.handle_interrupt! error
+    harness.__uspec_cli.handle_interrupt! error
   end
 
 end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -101,7 +101,7 @@ class Uspec::CLI
     MSG
     puts
     warn message
-    stats.failure << Uspec::Result.new(message, error, caller)
+    stats << Uspec::Result.new(message, error, caller)
 
     handle_interrupt! error
   end

--- a/lib/uspec/define.rb
+++ b/lib/uspec/define.rb
@@ -6,7 +6,7 @@ module Uspec
     end
 
     def spec description, &block
-      @__uspec_harness.spec description, &block
+      @__uspec_harness.spec_eval description, &block
     end
   end
 end

--- a/lib/uspec/define.rb
+++ b/lib/uspec/define.rb
@@ -1,0 +1,12 @@
+module Uspec
+  class Define
+
+    def initialize harness
+      @__uspec_harness = harness
+    end
+
+    def spec description, &block
+      @__uspec_harness.spec description, &block
+    end
+  end
+end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -6,7 +6,7 @@ module Uspec
 
     def initialize cli
       @cli = cli
-      @define = ::Uspec::Define.new self
+      @define = Uspec::Define.new self
     end
     attr_accessor :cli, :define
 
@@ -21,14 +21,14 @@ module Uspec
       if block then
         begin
           state = 1
-          raw_result = ::Uspec::Spec.new(self, description, &block).__uspec_block
+          raw_result = Uspec::Spec.new(self, description, &block).__uspec_block
           state = 2
         rescue Exception => raw_result
           state = 3
         end
       end
 
-      result = Result.new description, raw_result, caller
+      result = Uspec::Result.new description, raw_result, caller
 
       unless block then
         state = 4

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -35,13 +35,7 @@ module Uspec
         result.pending!
       end
 
-      if result.success?
-        stats.success << result
-      elsif result.pending?
-        stats.pending << result
-      else
-        stats.failure << result
-      end
+      stats << result
 
       print ': ', result.pretty, "\n"
     rescue => error
@@ -55,7 +49,7 @@ module Uspec
       MSG
       puts
       warn message
-      stats.failure << Uspec::Result.new(message, error, caller)
+      stats << Uspec::Result.new(message, error, caller)
     ensure
       cli.handle_interrupt! result.raw
       return [state, error, result, raw_result]

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -14,7 +14,7 @@ module Uspec
       cli.stats
     end
 
-    def spec description, &block
+    def spec_eval description, &block
       state = 0
       print ' -- ', description
 

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -6,10 +6,12 @@ module Uspec
 
     def initialize cli
       @__uspec_cli = cli
+      @__uspec_define = ::Uspec::Define.new self
     end
+    attr_accessor :__uspec_cli, :__uspec_define
 
-    def __uspec_cli
-      @__uspec_cli
+    def define
+      @__uspec_define
     end
 
     def __uspec_stats

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -5,17 +5,13 @@ module Uspec
   class Harness
 
     def initialize cli
-      @__uspec_cli = cli
-      @__uspec_define = ::Uspec::Define.new self
+      @cli = cli
+      @define = ::Uspec::Define.new self
     end
-    attr_accessor :__uspec_cli, :__uspec_define
+    attr_accessor :cli, :define
 
-    def define
-      @__uspec_define
-    end
-
-    def __uspec_stats
-      @__uspec_cli.stats
+    def stats
+      cli.stats
     end
 
     def spec description, &block
@@ -40,11 +36,11 @@ module Uspec
       end
 
       if result.success?
-        __uspec_stats.success << result
+        stats.success << result
       elsif result.pending?
-        __uspec_stats.pending << result
+        stats.pending << result
       else
-        __uspec_stats.failure << result
+        stats.failure << result
       end
 
       print ': ', result.pretty, "\n"
@@ -59,9 +55,9 @@ module Uspec
       MSG
       puts
       warn message
-      __uspec_stats.failure << Uspec::Result.new(message, error, caller)
+      stats.failure << Uspec::Result.new(message, error, caller)
     ensure
-      __uspec_cli.handle_interrupt! result.raw
+      cli.handle_interrupt! result.raw
       return [state, error, result, raw_result]
     end
   end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -2,7 +2,7 @@ require_relative "result"
 require_relative "spec"
 
 module Uspec
-  class DSL
+  class Harness
 
     def initialize cli
       @__uspec_cli = cli

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -5,7 +5,7 @@ module Uspec
   class Result
     include Terminal
 
-    PREFIX = "#{Terminal.newline}#{Terminal.yellow}>\t#{Terminal.normal}"
+    PREFIX = "#{Uspec::Terminal.newline}#{Uspec::Terminal.yellow}>\t#{Uspec::Terminal.normal}"
 
     def initialize spec, raw, source
       @spec = spec

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -27,10 +27,7 @@ module Uspec
           raise "Uspec: No block provided for `#{@__uspec_description}`"
         end
       end
-    end
+    end # initialize
 
-    def spec description, &block
-      @__uspec_harness.spec description, &block
-    end
   end
 end

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -5,18 +5,18 @@ module Uspec
 
     def initialize dsl, description, &block
       @__uspec_description = description
-      @__uspec_dsl = dsl
+      @__uspec_harness = dsl
 
       dsl.define.instance_variables.each do |name|
         self.instance_variable_set(
           name,
-          @__uspec_dsl.define.instance_variable_get(name)
+          @__uspec_harness.define.instance_variable_get(name)
         ) unless name.to_s.include? '@__uspec'
       end
 
       dsl.define.methods(false).each do |name|
         self.define_singleton_method name do |*args, &block|
-          @__uspec_dsl.define.send name, *args, &block
+          @__uspec_harness.define.send name, *args, &block
         end unless name.to_s.include? '__uspec'
       end
 
@@ -30,7 +30,7 @@ module Uspec
     end
 
     def spec description, &block
-      @__uspec_dsl.spec description, &block
+      @__uspec_harness.spec description, &block
     end
   end
 end

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -3,20 +3,21 @@ require_relative "result"
 module Uspec
   class Spec
 
-    def initialize dsl, description, &block
+    def initialize harness, description, &block
       @__uspec_description = description
-      @__uspec_harness = dsl
+      @__uspec_harness = harness
+      ns = harness.define
 
-      dsl.define.instance_variables.each do |name|
+      ns.instance_variables.each do |name|
         self.instance_variable_set(
           name,
-          @__uspec_harness.define.instance_variable_get(name)
+          ns.instance_variable_get(name)
         ) unless name.to_s.include? '@__uspec'
       end
 
-      dsl.define.methods(false).each do |name|
+      ns.methods(false).each do |name|
         self.define_singleton_method name do |*args, &block|
-          @__uspec_harness.define.send name, *args, &block
+          ns.send name, *args, &block
         end unless name.to_s.include? '__uspec'
       end
 
@@ -24,7 +25,7 @@ module Uspec
         self.define_singleton_method :__uspec_block, &block
       else
         self.define_singleton_method :__uspec_block do
-          raise "Uspec: No block provided for `#{@__uspec_description}`"
+          raise NotImplementedError, "Uspec: No block provided for `#{@__uspec_description}`"
         end
       end
     end # initialize

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -8,7 +8,10 @@ module Uspec
       @__uspec_dsl = dsl
 
       dsl.define.instance_variables.each do |name|
-        self.instance_variable_set(name, @__uspec_dsl.define.instance_variable_get(name)) unless name.to_s.include? '@__uspec'
+        self.instance_variable_set(
+          name,
+          @__uspec_dsl.define.instance_variable_get(name)
+        ) unless name.to_s.include? '@__uspec'
       end
 
       dsl.define.methods(false).each do |name|

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -7,18 +7,18 @@ module Uspec
       @__uspec_description = description
       @__uspec_dsl = dsl
 
-      dsl.instance_variables.each do |name|
-        self.instance_variable_set(name, @__uspec_dsl.instance_variable_get(name)) unless name.to_s.include? '@__uspec'
+      dsl.define.instance_variables.each do |name|
+        self.instance_variable_set(name, @__uspec_dsl.define.instance_variable_get(name)) unless name.to_s.include? '@__uspec'
       end
 
-      dsl.methods(false).each do |name|
+      dsl.define.methods(false).each do |name|
         self.define_singleton_method name do |*args, &block|
-          @__uspec_dsl.send name, *args, &block
+          @__uspec_dsl.define.send name, *args, &block
         end unless name.to_s.include? '__uspec'
       end
 
       if block then
-      self.define_singleton_method :__uspec_block, &block
+        self.define_singleton_method :__uspec_block, &block
       else
         self.define_singleton_method :__uspec_block do
           raise "Uspec: No block provided for `#{@__uspec_description}`"

--- a/lib/uspec/stats.rb
+++ b/lib/uspec/stats.rb
@@ -5,6 +5,16 @@ module Uspec
     end
     attr :success, :failure, :pending
 
+    def << result
+      if result.success?
+        self.success << result
+      elsif result.pending?
+        self.pending << result
+      else
+        self.failure << result
+      end
+    end
+
     def clear_results!
       @success = Array.new
       @failure = Array.new

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -49,7 +49,7 @@ end
 spec 'exit code is the number of failures' do
   expected = 50
   output = capture do
-    @__uspec_dsl.__uspec_stats.clear_results! # because we're forking, we will have a copy of the current results
+    @__uspec_harness.stats.clear_results! # because we're forking, we will have a copy of the current results
 
     expected.times do |count|
       spec "fail ##{count + 1}" do
@@ -57,7 +57,7 @@ spec 'exit code is the number of failures' do
       end
     end
 
-    exit @__uspec_dsl.__uspec_cli.exit_code
+    exit @__uspec_harness.cli.exit_code
   end
   actual = $?.exitstatus
 
@@ -66,7 +66,7 @@ end
 
 spec 'when more than 255 failures, exit status is 255' do
   output = capture do
-    @__uspec_dsl.__uspec_stats.clear_results! # because we're forking, we will have a copy of the current results
+    @__uspec_harness.stats.clear_results! # because we're forking, we will have a copy of the current results
 
     500.times do
       spec 'fail' do
@@ -74,7 +74,7 @@ spec 'when more than 255 failures, exit status is 255' do
       end
     end
 
-    exit @__uspec_dsl.__uspec_cli.exit_code
+    exit @__uspec_harness.cli.exit_code
   end
 
   $?.exitstatus == 255 || [$?, output]

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -4,20 +4,24 @@ def root
   Pathname.new(__FILE__).parent.parent
 end
 
-def examples
+def exdir
   root.join('example_specs')
 end
 
-def specs
+def specdir
   root.join('uspec')
 end
 
-def tests
-  specs.join('test_specs')
+def testdir
+  specdir.join('test_specs')
+end
+
+def new_cli path  = '.'
+  Uspec::CLI.new(Array(path))
 end
 
 def run_specs path
-  Uspec::CLI.new(Array(path)).run_specs
+  new_cli(path).run_specs
 end
 
 
@@ -30,36 +34,36 @@ spec 'shows usage' do
 end
 
 spec 'runs a path of specs' do
-  output = capture do
-    run_specs examples.to_s
+  output = outstr do
+    run_specs exdir.to_s
   end
 
   output.include?('I love passing tests') || output
 end
 
 spec 'runs an individual spec' do
-  output = capture do
-    run_specs examples.join('example_spec.rb').to_s
+  output = outstr do
+    run_specs exdir.join('example_spec.rb').to_s
   end
 
   output.include?('I love passing tests') || output
 end
 
 spec 'broken requires in test files count as test failures' do
-  output, status = Open3.capture2e "bin/uspec #{tests.join('broken_require_spec')}"
+  output, status = Open3.capture2e "#{root}/bin/uspec #{testdir.join('broken_require_spec')}"
 
   status.exitstatus == 1 || status
 end
 
 spec 'displays information about test file with broken require' do
-  output, status = Open3.capture2e "bin/uspec #{tests.join('broken_require_spec')}"
+  output, status = Open3.capture2e "#{root}/bin/uspec #{testdir.join('broken_require_spec')}"
 
   output.include?('cannot load such file') || output
 end
 
 spec 'exit code is the number of failures' do
   expected = 50
-  cli = Uspec::CLI.new(Array(path))
+  cli = new_cli
 
   outstr do
     expected.times do |count|
@@ -75,7 +79,7 @@ end
 
 spec 'when more than 255 failures, exit status is 255' do
   expected = 255
-  cli = Uspec::CLI.new(Array(path))
+  cli = new_cli
 
   output = outstr do
     500.times do

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -1,14 +1,5 @@
 require_relative 'uspec_helper'
 
-spec 'shows usage' do
-  output = capture do
-    exec 'bin/uspec -h'
-  end
-
-  output.include? 'usage'
-end
-
-
 def root
   Pathname.new(__FILE__).parent.parent
 end
@@ -27,6 +18,15 @@ end
 
 def run_specs path
   Uspec::CLI.new(Array(path)).run_specs
+end
+
+
+spec 'shows usage' do
+  output = capture do
+    exec 'bin/uspec -h'
+  end
+
+  output.include? 'usage'
 end
 
 spec 'runs a path of specs' do
@@ -70,7 +70,6 @@ spec 'exit code is the number of failures' do
   end
 
   actual = cli.exit_code
-
   actual == expected || output
 end
 
@@ -87,6 +86,5 @@ spec 'when more than 255 failures, exit status is 255' do
   end
 
   actual = cli.exit_code
-
   actual == expected || [$?, output]
 end

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -1,21 +1,5 @@
 require_relative 'uspec_helper'
 
-def root
-  Pathname.new(__FILE__).parent.parent
-end
-
-def exdir
-  root.join('example_specs')
-end
-
-def specdir
-  root.join('uspec')
-end
-
-def testdir
-  specdir.join('test_specs')
-end
-
 def new_cli path  = '.'
   Uspec::CLI.new(Array(path))
 end

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -59,34 +59,34 @@ end
 
 spec 'exit code is the number of failures' do
   expected = 50
-  output = capture do
-    @__uspec_harness.stats.clear_results! # because we're forking, we will have a copy of the current results
+  cli = Uspec::CLI.new(Array(path))
 
+  outstr do
     expected.times do |count|
-      spec "fail ##{count + 1}" do
+      cli.harness.define.spec "fail ##{count + 1}" do
         false
       end
     end
-
-    exit @__uspec_harness.cli.exit_code
   end
-  actual = $?.exitstatus
+
+  actual = cli.exit_code
 
   actual == expected || output
 end
 
 spec 'when more than 255 failures, exit status is 255' do
-  output = capture do
-    @__uspec_harness.stats.clear_results! # because we're forking, we will have a copy of the current results
+  expected = 255
+  cli = Uspec::CLI.new(Array(path))
 
+  output = outstr do
     500.times do
-      spec 'fail' do
+      cli.harness.define.spec 'fail' do
         false
       end
     end
-
-    exit @__uspec_harness.cli.exit_code
   end
 
-  $?.exitstatus == 255 || [$?, output]
+  actual = cli.exit_code
+
+  actual == expected || [$?, output]
 end

--- a/uspec/dsl_spec.rb
+++ b/uspec/dsl_spec.rb
@@ -21,9 +21,9 @@ spec 'catches even non-StandardError-subclass exceptions' do
 end
 
 spec 'Uspec exits when sent a termination signal' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'kill_this_spec')
+  path = testdir.join('kill_this_spec')
 
-  stdin, allout, thread = Open3.popen2e "uspec/test_specs/kill_this_script.sh \"#{path}\""
+  stdin, allout, thread = Open3.popen2e "#{testdir}/kill_this_script.sh \"#{path}\""
   stdin.close
   output = allout.read
 
@@ -50,10 +50,10 @@ spec 'complains when spec block returns non boolean' do
 end
 
 spec 'marks test as pending when no block supplied' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'pending_spec')
+  path = testdir.join('pending_spec')
 
   output = capture do
-    exec "bin/uspec #{path}"
+    exec "#{root}/bin/uspec #{path}"
   end
 
   output.include?('1 pending') || output
@@ -64,40 +64,40 @@ spec 'should not define DSL methods on arbitrary objects' do
 end
 
 spec 'when return used in spec, capture it as an error' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'return_spec')
+  path = testdir.join('return_spec')
 
   output = capture do
-    exec "bin/uspec #{path}"
+    exec "#{root}/bin/uspec #{path}"
   end
 
   output.include?('Invalid return') || output.include?('Spec did not return a boolean value') || output
 end
 
 spec 'when break used in spec, capture it as an error' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'break_spec')
+  path = testdir.join('break_spec')
 
   output = capture do
-    exec "bin/uspec #{path}"
+    exec "#{root}/bin/uspec #{path}"
   end
 
   output.include?('Invalid break') || output.include?('Spec did not return a boolean value') || output
 end
 
 spec 'when instance variables are defined in the DSL instance, they are available in the spec body' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'ivar_spec')
+  path = testdir.join('ivar_spec')
 
   output = capture do
-    exec "bin/uspec #{path}"
+    exec "#{root}/bin/uspec #{path}"
   end
 
   output.include?('1 successful') || output
 end
 
 spec 'when methods are defined in the DSL instance, they are available in the spec body' do
-  path =  Pathname.new(__FILE__).parent.join('test_specs', 'method_spec')
+  path = testdir.join('method_spec')
 
   output = capture do
-    exec "bin/uspec #{path}"
+    exec "#{root}/bin/uspec #{path}"
   end
 
   output.include?('1 successful') || output

--- a/uspec/dsl_spec.rb
+++ b/uspec/dsl_spec.rb
@@ -1,8 +1,10 @@
 require_relative "uspec_helper"
 
 spec 'catches errors' do
-  output = capture do
-    spec 'exception' do
+  cli = new_cli
+
+  output = outstr do
+    cli.harness.define.spec 'exception' do
       raise 'test exception'
     end
   end
@@ -11,8 +13,10 @@ spec 'catches errors' do
 end
 
 spec 'catches even non-StandardError-subclass exceptions' do
-  output = capture do
-    spec 'not implemented error' do
+  cli = new_cli
+
+  output = outstr do
+    cli.harness.define.spec 'not implemented error' do
       raise ::NotImplementedError, 'test exception'
     end
   end
@@ -40,8 +44,10 @@ spec 'Uspec exits when sent a termination signal' do
 end
 
 spec 'complains when spec block returns non boolean' do
-  output = capture do
-    spec 'whatever' do
+  cli = new_cli
+
+  output = outstr do
+    cli.harness.define.spec 'whatever' do
       "string"
     end
   end

--- a/uspec/stats_spec.rb
+++ b/uspec/stats_spec.rb
@@ -1,12 +1,12 @@
 require_relative 'uspec_helper'
 
 spec 'stats can be inspected' do
-  actual = @__uspec_dsl.__uspec_stats.inspect
+  actual = @__uspec_harness.stats.inspect
   actual.include?("failure") || actual
 end
 
 spec 'stats inspect does not have any stray whitespace' do
-  output = @__uspec_dsl.__uspec_stats.inspect
+  output = @__uspec_harness.stats.inspect
   match = output.match /(.*(?:  |\n))/m
   match == nil || match
 end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -26,11 +26,19 @@ def capture
 end
 
 def outstr
-  strio = StringIO.new
   old_stdout = $stdout
-  $stdout = strio
+  old_stderr = $stderr
 
-  yield
+  outio = StringIO.new
+  $stdout = outio
+
+  errio = StringIO.new
+  $stderr = errio
+
+  val = yield
+
+  outio.string + errio.string
 ensure
   $stdout = old_stdout
+  $stderr = old_stderr
 end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -24,3 +24,13 @@ def capture
 
   output
 end
+
+def outstr
+  strio = StringIO.new
+  old_stdout = $stdout
+  $stdout = strio
+
+  yield
+ensure
+  $stdout = old_stdout
+end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -4,6 +4,7 @@ rescue LoadError => err
   nil
 end
 require 'open3'
+require 'stringio'
 
 require_relative '../lib/uspec'
 extend Uspec

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -42,3 +42,19 @@ ensure
   $stdout = old_stdout
   $stderr = old_stderr
 end
+
+def root
+  Pathname.new(__FILE__).parent.parent
+end
+
+def exdir
+  root.join('example_specs')
+end
+
+def specdir
+  root.join('uspec')
+end
+
+def testdir
+  specdir.join('test_specs')
+end


### PR DESCRIPTION
The `Define` object is now the context that specs are defined in. It is not intended to be a pristine context, it is a standard `Object` with access to `Kernel` methods. But it contains only the bare minimum of influence from `Uspec` containing only the methods that the test author uses as part of the Uspec DSL (`spec`) and a single ivar that connects that `Define` instance back to the primary inner workings of the test `Harness`.

The `Harness` acts as the core functionality of `Uspec` - that is to say that it wraps the evaluation of specs and handle errors. It contains the bulk of the code from the former `DSL` object, but it is no longer obfuscated and not accessed directly by the test author making it less brittle and easier to refactor.

The `Spec` object continues to provide the evaluation context using information provided by the `Define` instance. This means that each `spec` is evaluated in its own unique environment, but can still used shared objects. It also allows for early `return` at any point in a `spec` because at runtime it is simply a method. 

The `Stats` object acquires a new capability, moved from the former `DSL` object, that allows it to manage where `Result`s end up internally. This also means that callsites no longer need to think about what kind of `Result` they are supplying. So in the future where `Exception` values are returned as opposed to `Exception`s being `rescue`d the differentiation can be handled between the `Result` and `Stats` without other objects having to worry about it.