### PR TITLE
Distinguish between Exception values and raised Exceptions

### DIFF
--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -101,7 +101,7 @@ class Uspec::CLI
     MSG
     puts
     warn message
-    stats << Uspec::Result.new(message, error, caller)
+    stats << Uspec::Result.new(message, error, true, caller)
 
     handle_interrupt! error
   end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -15,6 +15,7 @@ module Uspec
     end
 
     def spec_eval description, &block
+      ex = nil
       state = 0
       print ' -- ', description
 
@@ -25,10 +26,11 @@ module Uspec
           state = 2
         rescue Exception => raw_result
           state = 3
+          ex = true
         end
       end
 
-      result = Uspec::Result.new description, raw_result, caller
+      result = Uspec::Result.new description, raw_result, ex, caller
 
       unless block then
         state = 4

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -7,13 +7,14 @@ module Uspec
 
     PREFIX = "#{Uspec::Terminal.newline}#{Uspec::Terminal.yellow}>\t#{Uspec::Terminal.normal}"
 
-    def initialize spec, raw, source
+    def initialize spec, raw, ex, source
       @spec = spec
       @raw = raw
+      @ex = ex
       @source = source
       @handler = ::TOISB.wrap raw
     end
-    attr_reader :spec, :raw, :source, :handler
+    attr_reader :spec, :raw, :ex, :source, :handler
 
     def pretty
       if raw == true then

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -23,7 +23,7 @@ module Uspec
         red raw
       elsif pending? then
         yellow 'pending'
-      elsif Exception === raw then
+      elsif ex == true then
         [
           red('Exception'), vspace,
           hspace, 'Spec encountered an Exception ', newline,
@@ -32,6 +32,7 @@ module Uspec
           white(trace)
         ].join
       else
+        #if Exception === raw then
         [
           red('Failed'), vspace,
           hspace, 'Spec did not return a boolean value ', newline,
@@ -42,9 +43,10 @@ module Uspec
     end
 
     def trace
-      raw.backtrace.inject(String.new) do |text, line|
+      bt = raw.backtrace
+      bt.inject(String.new) do |text, line|
         text << "#{hspace}#{line}#{newline}"
-      end
+      end if bt
     end
 
     def message
@@ -59,10 +61,15 @@ module Uspec
     def inspector
       if String === raw && raw.include?(?\n) then
         # if object is a multiline string, display it unescaped
-
         [
           raw.split(newline).unshift(newline).join(PREFIX), normal, newline,
         ].join
+      elsif Exception === raw then
+        [
+          raw.message, vspace,
+          white(trace),
+          normal, newline,
+      ].join
       else
         handler.inspector!
       end

--- a/uspec/result_spec.rb
+++ b/uspec/result_spec.rb
@@ -68,9 +68,36 @@ spec "display strings more like their actual contents" do
   actual.match?(expected) || result.inspector
 end
 
+def exception_value
+  raise "A test exception!"
+rescue => err
+  return err
+end
+
 spec "handles exception values" do
-  result = Uspec::Result.new "Exception Value Result", Exception, nil, []
-  expected = "Class < Module: \e[0mException Class"
+  result = Uspec::Result.new "Exception Value Result", exception_value, nil, caller
+  expected = "RuntimeError < StandardError: \e[0mA test exception!"
+  actual =  result.pretty
+  actual.include?(expected) || result.pretty
+end
+
+spec "handles exception values including backtraces" do
+  result = Uspec::Result.new "Exception Value Result", exception_value, nil, caller
+  expected = "exception_value"
+  actual =  result.pretty
+  actual.include?(expected) || result.pretty
+end
+
+spec "handles raised exceptions" do
+  result = Uspec::Result.new "Exception Raised Result", exception_value, true, caller
+  expected = "RuntimeError < StandardError: \e[0mA test exception!"
+  actual =  result.pretty
+  actual.include?(expected) || result.pretty
+end
+
+spec "handles raised exceptions without backtraces" do
+  result = Uspec::Result.new "Exception Raised Result", Exception.new, true, caller
+  expected = "Exception < Object: \e[0mException"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end

--- a/uspec/result_spec.rb
+++ b/uspec/result_spec.rb
@@ -3,7 +3,7 @@ require_relative "uspec_helper"
 bo = BasicObject.new
 
 spec "#pretty doesn't die when given a BasicObject" do
-  result = Uspec::Result.new "BasicObject Result", bo, []
+  result = Uspec::Result.new "BasicObject Result", bo, nil, []
   expected = "#<BasicObject:"
   actual = result.pretty
   actual.include?(expected) || actual
@@ -14,28 +14,28 @@ class ::TestObject < BasicObject; end
 obj = TestObject.new
 
 spec "ensure BasicObject subclass instances work" do
-  result = Uspec::Result.new "BasicObject Subclass Result", obj, []
+  result = Uspec::Result.new "BasicObject Subclass Result", obj, nil, []
   expected = "#<BasicObject/TestObject:"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Object" do
-  result = Uspec::Result.new "Object Result", Object.new, []
+  result = Uspec::Result.new "Object Result", Object.new, nil, []
   expected = "Object < BasicObject: \e[0m#<Object:"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Array" do
-  result = Uspec::Result.new "Array Result", [], []
+  result = Uspec::Result.new "Array Result", [], nil, []
   expected = "Array < Object"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Array class" do
-  result = Uspec::Result.new "Array Class Result", Array, []
+  result = Uspec::Result.new "Array Class Result", Array, nil, []
   expected = "Class < Module: \e[0mArray Class"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
@@ -44,7 +44,7 @@ end
 parent = [obj]
 
 spec "ensure parent object of BasicObject subclasses get a useful error message" do
-  result = Uspec::Result.new "BasicObject Parent Result", parent, []
+  result = Uspec::Result.new "BasicObject Parent Result", parent, nil, []
   expected = "BasicObject and its subclasses"
   actual =  result.pretty
   actual.include?(expected) || result.inspector
@@ -54,7 +54,7 @@ class ::InspectFail; def inspect; raise RuntimeError, "This error is intentional
 inspect_fail = InspectFail.new
 
 spec "display a useful error message when a user-defined inspect method fails" do
-  result = Uspec::Result.new "Inspect Fail Result", inspect_fail, []
+  result = Uspec::Result.new "Inspect Fail Result", inspect_fail, nil, []
   expected = "raises an exception"
   actual =  result.pretty
   actual.include?(expected) || result.inspector
@@ -63,7 +63,14 @@ end
 spec "display strings more like their actual contents" do
   string = "this string:\nshould display \e\[42;2mproperly"
   expected = /this string:\n.*should display \e\[42;2mproperly/
-  result = Uspec::Result.new "Inspect Fail Result", string, []
+  result = Uspec::Result.new "Inspect Fail Result", string, nil, []
   actual =  result.pretty
   actual.match?(expected) || result.inspector
+end
+
+spec "handles exception values" do
+  result = Uspec::Result.new "Exception Value Result", Exception, nil, []
+  expected = "Class < Module: \e[0mException Class"
+  actual =  result.pretty
+  actual.include?(expected) || result.pretty
 end


### PR DESCRIPTION
Uspec can now distinguish between an object being returned from a `spec` block which happens to be an instance of an `Exception` class and an actual `Exception` rescued directly by Uspec's harness. 

Values are displayed similar to other non-boolean values with the same message, except that the stack trace is included in the output.

Rescued `Exceptions` are displayed as they were before.

As requested by @BrianHawley