### PR TITLE
Improve Backtraces

### DIFF
--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -1,8 +1,3 @@
-require_relative 'uspec/version'
-require_relative 'uspec/harness'
-require_relative 'uspec/define'
-require_relative 'uspec/stats'
-
 module Uspec
   def self.included object
     warn 'Use extend instead of include.'
@@ -15,4 +10,13 @@ module Uspec
     #  object.extend Uspec::DSL
     #end
   end
+
+  def self.libpath
+    Pathname.new(__FILE__).dirname.dirname
+  end
 end
+
+require_relative 'uspec/version'
+require_relative 'uspec/harness'
+require_relative 'uspec/define'
+require_relative 'uspec/stats'

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -74,36 +74,10 @@ class Uspec::CLI
       end
     elsif path.exist? then
       puts "#{path.basename path.extname}:"
-      harness.define.instance_eval(path.read, path.to_s)
+      harness.file_eval path
     else
       warn "path not found: #{path}"
     end
-  rescue Exception => error
-
-    if SignalException === error || SystemExit === error then
-      exit 3
-    end
-
-    error_file, error_line, _ = error.backtrace.first.split ?:
-
-    message = <<-MSG
-      #{error.class} : #{error.message}
-
-      Uspec encountered an error when loading a test file.
-      This is probably a typo in the test file or the file it is testing.
-
-      If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
-
-      Error occured when loading test file `#{spec || path}`.
-      The origin of the error may be in file `#{error_file}` on line ##{error_line}.
-
-\t#{error.backtrace[0,3].join "\n\t"}
-    MSG
-    puts
-    warn message
-    stats << Uspec::Result.new(message, error, true, caller)
-
-    handle_interrupt! error
   end
 
 end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -17,7 +17,6 @@ module Uspec
     def file_eval path
       define.instance_eval(path.read, path.to_s)
     rescue Exception => error
-
       if SignalException === error || SystemExit === error then
         exit 3
       end
@@ -42,7 +41,6 @@ module Uspec
       stats << Uspec::Result.new(message, error, true, caller)
 
       cli.handle_interrupt! error
-
     end
 
     def spec_eval description, &block
@@ -82,7 +80,7 @@ module Uspec
       MSG
       puts
       warn message
-      stats << Uspec::Result.new(message, error, caller)
+      stats << Uspec::Result.new(message, error, true, caller)
     ensure
       cli.handle_interrupt! result.raw
       return [state, error, result, raw_result]

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -38,7 +38,7 @@ module Uspec
       MSG
       puts
       warn message
-      stats << Uspec::Result.new(message, error, true, caller)
+      stats << Uspec::Result.new(message, error, true)
 
       cli.handle_interrupt! error
     end
@@ -59,7 +59,7 @@ module Uspec
         end
       end
 
-      result = Uspec::Result.new description, raw_result, ex, caller
+      result = Uspec::Result.new description, raw_result, ex
 
       unless block then
         state = 4
@@ -80,7 +80,7 @@ module Uspec
       MSG
       puts
       warn message
-      stats << Uspec::Result.new(message, error, true, caller)
+      stats << Uspec::Result.new(message, error, true)
     ensure
       cli.handle_interrupt! result.raw
       return [state, error, result, raw_result]

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -51,7 +51,8 @@ module Uspec
       if block then
         begin
           state = 1
-          raw_result = Uspec::Spec.new(self, description, &block).__uspec_block
+          spec = Uspec::Spec.new(self, description, &block)
+          raw_result = spec.__uspec_block
           state = 2
         rescue Exception => raw_result
           state = 3
@@ -59,7 +60,7 @@ module Uspec
         end
       end
 
-      result = Uspec::Result.new description, raw_result, ex
+      result = Uspec::Result.new spec, raw_result, ex
 
       unless block then
         state = 4

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -14,6 +14,37 @@ module Uspec
       cli.stats
     end
 
+    def file_eval path
+      define.instance_eval(path.read, path.to_s)
+    rescue Exception => error
+
+      if SignalException === error || SystemExit === error then
+        exit 3
+      end
+
+      error_file, error_line, _ = error.backtrace.first.split ?:
+
+      message = <<-MSG
+        #{error.class} : #{error.message}
+
+        Uspec encountered an error when loading a test file.
+        This is probably a typo in the test file or the file it is testing.
+
+        If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
+
+        Error occured when loading test file `#{spec || path}`.
+        The origin of the error may be in file `#{error_file}` on line ##{error_line}.
+
+  \t#{error.backtrace[0,3].join "\n\t"}
+      MSG
+      puts
+      warn message
+      stats << Uspec::Result.new(message, error, true, caller)
+
+      cli.handle_interrupt! error
+
+    end
+
     def spec_eval description, &block
       ex = nil
       state = 0

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -81,6 +81,16 @@ module Uspec
       "#{handler.subklassinfo}: "
     end
 
+    def desc
+      if String === spec then
+        spec
+      elsif Uspec::Spec === spec then
+        spec.instance_variable_get :@__uspec_description
+      else
+        spec.inspect
+      end
+    end
+
     # Attempts to inspect an object
     def inspector
       if String === raw && raw.include?(?\n) then
@@ -114,7 +124,7 @@ module Uspec
 
       If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
 
-      Error may have occured in test `#{spec}` in file `#{error_file}` on line ##{error_line}.
+      Error may have occured in test `#{desc}` in file `#{error_file}` on line ##{error_line}.
 
 \t#{error.backtrace.join "\n\t"}
       MSG
@@ -137,7 +147,7 @@ module Uspec
     end
 
     def inspect
-      "#{self.class} for `#{spec}` -> #{pretty}"
+      "#{self.class} for `#{desc}` -> #{pretty}"
     end
   end
 end

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -6,15 +6,17 @@ module Uspec
     include Terminal
 
     PREFIX = "#{Uspec::Terminal.newline}#{Uspec::Terminal.yellow}>\t#{Uspec::Terminal.normal}"
+    TRACE_EXCLUDE_PATTERN = /uspec\/lib|bin\/uspec/
 
-    def initialize spec, raw, ex, source
+    def initialize spec, raw, ex
       @spec = spec
       @raw = raw
       @ex = ex
-      @source = source
       @handler = ::TOISB.wrap raw
+      @full_backtrace = false
+      @caller = caller
     end
-    attr_reader :spec, :raw, :ex, :source, :handler
+    attr_reader :spec, :raw, :ex, :handler, :full_backtrace
 
     def pretty
       if raw == true then
@@ -32,7 +34,6 @@ module Uspec
           white(trace)
         ].join
       else
-        #if Exception === raw then
         [
           red('Failed'), vspace,
           hspace, 'Spec did not return a boolean value ', newline,
@@ -43,10 +44,33 @@ module Uspec
     end
 
     def trace
-      bt = raw.backtrace
+      @backtrace ||= indent_bt clean_bt(raw.backtrace, !full_backtrace)
+    end
+
+    def source
+      @source ||= clean_bt @caller
+    end
+
+    def indent_bt bt
       bt.inject(String.new) do |text, line|
         text << "#{hspace}#{line}#{newline}"
       end if bt
+    end
+
+    def clean_bt bt, skip_internal = true
+      bt.inject(Array.new) do |t, line|
+        next t if skip_internal && line.match(TRACE_EXCLUDE_PATTERN)
+        t << rewrite_bt_caller(line)
+      end if bt
+    end
+
+    def rewrite_bt_caller line
+      return line if full_backtrace
+      if line.match TRACE_EXCLUDE_PATTERN then
+        line
+      else
+        line.sub /file_eval/, 'spec_block'
+      end
     end
 
     def message

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -6,7 +6,7 @@ module Uspec
     include Terminal
 
     PREFIX = "#{Uspec::Terminal.newline}#{Uspec::Terminal.yellow}>\t#{Uspec::Terminal.normal}"
-    TRACE_EXCLUDE_PATTERN = /uspec\/lib|bin\/uspec/
+    TRACE_EXCLUDE_PATTERN = /#{Uspec.libpath.join 'lib'}|#{Uspec.libpath.join 'bin'}/
 
     def initialize spec, raw, ex
       @spec = spec

--- a/lib/uspec/spec.rb
+++ b/lib/uspec/spec.rb
@@ -5,6 +5,7 @@ module Uspec
 
     def initialize harness, description, &block
       @__uspec_description = description
+      @__uspec_block = block
       @__uspec_harness = harness
       ns = harness.define
 

--- a/uspec/result_spec.rb
+++ b/uspec/result_spec.rb
@@ -3,7 +3,7 @@ require_relative "uspec_helper"
 bo = BasicObject.new
 
 spec "#pretty doesn't die when given a BasicObject" do
-  result = Uspec::Result.new "BasicObject Result", bo, nil, []
+  result = Uspec::Result.new "BasicObject Result", bo, nil
   expected = "#<BasicObject:"
   actual = result.pretty
   actual.include?(expected) || actual
@@ -14,28 +14,28 @@ class ::TestObject < BasicObject; end
 obj = TestObject.new
 
 spec "ensure BasicObject subclass instances work" do
-  result = Uspec::Result.new "BasicObject Subclass Result", obj, nil, []
+  result = Uspec::Result.new "BasicObject Subclass Result", obj, nil
   expected = "#<BasicObject/TestObject:"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Object" do
-  result = Uspec::Result.new "Object Result", Object.new, nil, []
+  result = Uspec::Result.new "Object Result", Object.new, nil
   expected = "Object < BasicObject: \e[0m#<Object:"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Array" do
-  result = Uspec::Result.new "Array Result", [], nil, []
+  result = Uspec::Result.new "Array Result", [], nil
   expected = "Array < Object"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "display basic info about Array class" do
-  result = Uspec::Result.new "Array Class Result", Array, nil, []
+  result = Uspec::Result.new "Array Class Result", Array, nil
   expected = "Class < Module: \e[0mArray Class"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
@@ -44,7 +44,7 @@ end
 parent = [obj]
 
 spec "ensure parent object of BasicObject subclasses get a useful error message" do
-  result = Uspec::Result.new "BasicObject Parent Result", parent, nil, []
+  result = Uspec::Result.new "BasicObject Parent Result", parent, nil
   expected = "BasicObject and its subclasses"
   actual =  result.pretty
   actual.include?(expected) || result.inspector
@@ -54,7 +54,7 @@ class ::InspectFail; def inspect; raise RuntimeError, "This error is intentional
 inspect_fail = InspectFail.new
 
 spec "display a useful error message when a user-defined inspect method fails" do
-  result = Uspec::Result.new "Inspect Fail Result", inspect_fail, nil, []
+  result = Uspec::Result.new "Inspect Fail Result", inspect_fail, nil
   expected = "raises an exception"
   actual =  result.pretty
   actual.include?(expected) || result.inspector
@@ -63,7 +63,7 @@ end
 spec "display strings more like their actual contents" do
   string = "this string:\nshould display \e\[42;2mproperly"
   expected = /this string:\n.*should display \e\[42;2mproperly/
-  result = Uspec::Result.new "Inspect Fail Result", string, nil, []
+  result = Uspec::Result.new "Inspect Fail Result", string, nil
   actual =  result.pretty
   actual.match?(expected) || result.inspector
 end
@@ -75,29 +75,36 @@ rescue => err
 end
 
 spec "handles exception values" do
-  result = Uspec::Result.new "Exception Value Result", exception_value, nil, caller
+  result = Uspec::Result.new "Exception Value Result", exception_value, nil
   expected = "RuntimeError < StandardError: \e[0mA test exception!"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "handles exception values including backtraces" do
-  result = Uspec::Result.new "Exception Value Result", exception_value, nil, caller
+  result = Uspec::Result.new "Exception Value Result", exception_value, nil
   expected = "exception_value"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "handles raised exceptions" do
-  result = Uspec::Result.new "Exception Raised Result", exception_value, true, caller
+  result = Uspec::Result.new "Exception Raised Result", exception_value, true
   expected = "RuntimeError < StandardError: \e[0mA test exception!"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
 end
 
 spec "handles raised exceptions without backtraces" do
-  result = Uspec::Result.new "Exception Raised Result", Exception.new, true, caller
+  result = Uspec::Result.new "Exception Raised Result", Exception.new, true
   expected = "Exception < Object: \e[0mException"
   actual =  result.pretty
   actual.include?(expected) || result.pretty
+end
+
+spec "doesn't show 'run' for spec file in stack trace" do
+  result = Uspec::Result.new "No Run Exception Trace Result", exception_value, true
+  expected = "run"
+  actual =  result.pretty
+  !actual.include?(expected) || result.pretty
 end

--- a/uspec/result_spec.rb
+++ b/uspec/result_spec.rb
@@ -104,7 +104,7 @@ end
 
 spec "doesn't show 'run' for spec file in stack trace" do
   result = Uspec::Result.new "No Run Exception Trace Result", exception_value, true
-  expected = "run"
+  expected = /uspec.*run/
   actual =  result.pretty
-  !actual.include?(expected) || result.pretty
+  !actual.match?(expected) || result.pretty
 end


### PR DESCRIPTION
Backtraces no longer show internal Uspec paths to make it easier for test authors to see what part of their code is involved. Still displays full trace for internal errors.

Corrects a weird issue where Ruby inserts the name of a different method in backtraces when dynamically defined methods are in the call chain instead of the actually place where it was defined or called.