### PR TITLE
Add ability to run a single spec within a file

### DIFF
--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -67,17 +67,18 @@ class Uspec::CLI
   end
 
   def run path
-    spec = nil
+    p, line = path.to_s.split(?:)
+    path = Pathname.new p
+
     if path.directory? then
       Pathname.glob(path.join('**', '**_spec.rb')).each do |spec|
         run spec
       end
     elsif path.exist? then
       puts "#{path.basename path.extname}:"
-      harness.file_eval path
+      harness.file_eval path, line
     else
       warn "path not found: #{path}"
     end
   end
-
 end

--- a/lib/uspec/define.rb
+++ b/lib/uspec/define.rb
@@ -6,7 +6,7 @@ module Uspec
     end
 
     def spec description, &block
-      @__uspec_harness.spec_eval description, &block
+      @__uspec_harness.spec_eval description, caller, &block
     end
   end
 end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -14,7 +14,9 @@ module Uspec
       cli.stats
     end
 
-    def file_eval path
+    def file_eval path, line
+      @path = path
+      @line = line
       define.instance_eval(path.read, path.to_s)
     rescue Exception => error
       if SignalException === error || SystemExit === error then
@@ -43,7 +45,9 @@ module Uspec
       cli.handle_interrupt! error
     end
 
-    def spec_eval description, &block
+    def spec_eval description, source, &block
+      return if @line && !source.first.include?("#{@path}:#{@line}")
+
       ex = nil
       state = 0
       print ' -- ', description
@@ -84,7 +88,7 @@ module Uspec
       warn message
       stats << result
     ensure
-      cli.handle_interrupt! result.raw
+      cli.handle_interrupt! result.raw if result
       return [state, error, result, raw_result]
     end
   end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -79,9 +79,10 @@ module Uspec
 
 \t#{error.backtrace.join "\n\t"}
       MSG
+      result = Uspec::Result.new(message, error, true)
       puts
       warn message
-      stats << Uspec::Result.new(message, error, true)
+      stats << result
     ensure
       cli.handle_interrupt! result.raw
       return [state, error, result, raw_result]

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -31,7 +31,7 @@ module Uspec
 
         If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
 
-        Error occured when loading test file `#{spec || path}`.
+        Error occured when loading test file `#{path}`.
         The origin of the error may be in file `#{error_file}` on line ##{error_line}.
 
   \t#{error.backtrace[0,3].join "\n\t"}

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -25,12 +25,20 @@ spec 'runs a path of specs' do
   output.include?('I love passing tests') || output
 end
 
-spec 'runs an individual spec' do
+spec 'runs an individual file' do
   output = outstr do
     run_specs exdir.join('example_spec.rb').to_s
   end
 
   output.include?('I love passing tests') || output
+end
+
+spec 'runs an individual spec' do
+  output = outstr do
+    run_specs exdir.join('example_spec.rb:13').to_s
+  end
+
+  !output.include?('I love passing tests') && output.include?('non-boolean') || output
 end
 
 spec 'broken requires in test files count as test failures' do


### PR DESCRIPTION
By putting a colon `:` and a line number at the end of a filename, Uspec will run only that spec.

The number must match the line number of the spec in the file exactly.