### PR TITLE
Refactor Errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in uspec.gemspec
 gemspec
 
-group :development do
+unless ENV['CI'] then
   gem 'pry'
   gem 'pry-doc'
   gem 'pry-theme'
   gem 'pry-coolline'
-end unless ENV['CI']
+end

--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,9 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in uspec.gemspec
 gemspec
 
-unless ENV['CI'] then
+group :development do
   gem 'pry'
   gem 'pry-doc'
   gem 'pry-theme'
   gem 'pry-coolline'
-end
+end unless ENV['CI']

--- a/example_specs/example_spec.rb
+++ b/example_specs/example_spec.rb
@@ -16,5 +16,5 @@ end
 
 spec 'Exceptions are handled and displayed' do
   class ExampleError < RuntimeError; end
-  raise ExampleError
+  raise ExampleError, "an example error for demonstration"
 end

--- a/lib/uspec.rb
+++ b/lib/uspec.rb
@@ -17,6 +17,7 @@ module Uspec
 end
 
 require_relative 'uspec/version'
+require_relative 'uspec/errors'
 require_relative 'uspec/harness'
 require_relative 'uspec/define'
 require_relative 'uspec/stats'

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -3,8 +3,6 @@ require_relative '../uspec'
 
 class Uspec::CLI
   def initialize args
-    usage unless (args & %w[-h --help -? /? -v --version]).empty?
-
     @paths = args
     @pwd = Pathname.pwd.freeze
     @stats = Uspec::Stats.new
@@ -15,6 +13,9 @@ class Uspec::CLI
   def usage
     warn "uspec v#{::Uspec::VERSION} - minimalistic ruby testing framework"
     warn "usage: #{File.basename $0} [<file_or_path>...]"
+    warn ""
+    warn "\t\t--full_backtrace\tshow full backtrace"
+    warn "\t\t--\tstop checking paths for options (good if a path begins with a dash)"
     exit 1
   end
 
@@ -23,6 +24,7 @@ class Uspec::CLI
   end
 
   def invoke
+    parse_options @paths
     run_specs
     die!
   end
@@ -61,6 +63,8 @@ class Uspec::CLI
   end
 
   def run_paths
+    check_options = true
+
     paths.each do |path|
       run @pwd.join path
     end
@@ -79,6 +83,22 @@ class Uspec::CLI
       harness.file_eval path, line
     else
       warn "path not found: #{path}"
+    end
+  end
+
+  def parse_options args
+    usage unless (args & %w[-h --help -? /? -v --version]).empty?
+
+    args.each_with_index do |arg, i|
+      if arg == '--' then
+        return args
+      elsif arg == '--full_backtrace' then
+        Uspec::Errors.full_backtrace!
+        args.delete_at i
+      elsif arg[0] == ?- then
+        warn "unknown option: #{arg}"
+        args.delete_at i
+      end
     end
   end
 end

--- a/lib/uspec/cli.rb
+++ b/lib/uspec/cli.rb
@@ -15,7 +15,7 @@ class Uspec::CLI
     warn "usage: #{File.basename $0} [<file_or_path>...]"
     warn ""
     warn "\t\t--full_backtrace\tshow full backtrace"
-    warn "\t\t--\tstop checking paths for options (good if a path begins with a dash)"
+    warn "\t\t--\t\t\tstop checking paths for options (good if a path begins with a dash)"
     exit 1
   end
 
@@ -87,14 +87,14 @@ class Uspec::CLI
   end
 
   def parse_options args
-    usage unless (args & %w[-h --help -? /? -v --version]).empty?
-
     args.each_with_index do |arg, i|
       if arg == '--' then
         return args
       elsif arg == '--full_backtrace' then
         Uspec::Errors.full_backtrace!
         args.delete_at i
+      elsif !(args & %w[-h --help -? /? -v --version]).empty?
+        usage
       elsif arg[0] == ?- then
         warn "unknown option: #{arg}"
         args.delete_at i

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -63,17 +63,11 @@ module Uspec
     end
 
     def msg_spec_value error
-      if error.backtrace then
-        bt = error.backtrace
-      else
-        bt = caller
-      end
-
-      error_info = white bt_format bt
+      error_info = white bt_format(bt_get error)
 
       message = <<~MSG
-      #{error.message}
-      #{error_info}
+        #{error.message}
+        #{error_info}
       MSG
 
       error_indent error, message, header: false
@@ -98,17 +92,17 @@ module Uspec
     end
 
     def error_context error, skip_internal: true
-      if error.backtrace then
-        bt = error.backtrace
-      else
-        bt = caller[2..-1]
-      end
+      bt = bt_get error
       error_line = bt.first.split(?:)
       [
         error_origin(*error_line),
         white(bt_format(bt, skip_internal)),
         MSG_IF_USPEC_BUG
       ].join ?\n
+    end
+
+    def bt_get error
+      error.backtrace || caller[3..-1]
     end
 
     def error_origin error_file, error_line, *_

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -25,13 +25,7 @@ module Uspec
         #{error_info}
       MSG
 
-      result = Uspec::Result.new(message, error, true)
-
-      puts
-      warn error_indent error, message
-
-      cli.handle_interrupt! result.raw if cli
-      result
+      handle_error message, error, cli
     end
 
     def handle_internal_error error, cli = nil
@@ -42,6 +36,10 @@ module Uspec
         #{error_info}
       MSG
 
+      handle_error message, error, cli
+    end
+
+    def handle_error message, error, cli
       result = Uspec::Result.new(message, error, true)
 
       puts

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -14,19 +14,14 @@ module Uspec
         exit 3
       end
 
-      error_bt   = bt_indent error.backtrace[0,3]
-      error_file = error_origin *error.backtrace.first.split(?:)
+      error_info = error_context error.backtrace.first.split(?:), error.backtrace[0,3]
 
       message = <<~MSG
         Uspec encountered an error when loading a test file.
         This is probably a typo in the test file or the file it is testing.
 
         Error occured when loading test file `#{path}`.
-        #{error_file}
-
-        #{error_bt}
-
-        #{MSG_IF_USPEC_BUG}
+        #{error_info}
       MSG
 
       result = Uspec::Result.new(message, error, true)
@@ -39,14 +34,11 @@ module Uspec
     end
 
     def handle_internal_error error, cli = nil
-      error_bt   = bt_indent error.backtrace
+      error_info = error_context error.backtrace.first.split(?:), error.backtrace
 
       message = <<~MSG
         Uspec encountered an internal error!
-
-        #{error_bt}
-
-        #{MSG_IF_USPEC_BUG}
+        #{error_info}
       MSG
 
       result = Uspec::Result.new(message, error, true)
@@ -59,8 +51,7 @@ module Uspec
     end
 
     def msg_source_error error, desc, cli = nil
-      error_bt   = bt_indent error.backtrace
-      error_file = error_origin *error.backtrace[4].split(?:)
+      error_info = error_context error.backtrace[4].split(?:), error.backtrace
 
       message = <<~MSG
         Uspec detected a bug in your source code!
@@ -71,14 +62,20 @@ module Uspec
         This is most likely to happen with BasicObject and its subclasses.
 
         Error occured when evaluating spec `#{desc}`.
-        #{error_file}
-
-        #{error_bt}
-
-        #{MSG_IF_USPEC_BUG}
+        #{error_info}
       MSG
 
       error_indent error, message, false
+    end
+
+    def error_context error_file, error_bt
+      message = <<~MSG
+        #{error_origin *error_file}
+
+        #{bt_indent error_bt}
+
+        #{MSG_IF_USPEC_BUG}
+      MSG
     end
 
     def error_header error

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -78,10 +78,6 @@ module Uspec
       MSG
     end
 
-    def error_header error
-      "#{error.class} : #{error.message}"
-    end
-
     def error_origin error_file, error_line, *_
       "The origin of the error may be in file `#{error_file}` on line ##{error_line}."
     end
@@ -91,6 +87,10 @@ module Uspec
       a.unshift "#{hspace if first_line_indent}#{error_header error}#{newline}"
       a << ""
       a.join("#{newline}#{hspace}")
+    end
+
+    def error_header error
+      "#{error.class} : #{error.message}"
     end
 
     def bt_indent bt

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -1,0 +1,53 @@
+module Uspec
+  module Errors
+    module_function
+
+    def handle_internal_error error, cli = nil
+      message = <<-MSG
+      #{error.class} : #{error.message}
+
+      Uspec encountered an internal error, please report this bug: https://github.com/acook/uspec/issues/new
+
+\t#{error.backtrace.join "\n\t"}
+      MSG
+
+      result = Uspec::Result.new(message, error, true)
+
+      puts
+      warn message
+
+      cli.handle_interrupt! result.raw if cli
+      return result
+    end
+
+    def handle_file_error error, path, cli = nil
+      if SignalException === error || SystemExit === error then
+        exit 3
+      end
+
+      error_file, error_line, _ = error.backtrace.first.split ?:
+
+      message = <<-MSG
+        #{error.class} : #{error.message}
+
+        Uspec encountered an error when loading a test file.
+        This is probably a typo in the test file or the file it is testing.
+
+        If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
+
+        Error occured when loading test file `#{path}`.
+        The origin of the error may be in file `#{error_file}` on line ##{error_line}.
+
+  \t#{error.backtrace[0,3].join "\n\t"}
+      MSG
+
+      result = Uspec::Result.new(message, error, true)
+
+      puts
+      warn message
+
+      cli.handle_interrupt! result.raw if cli
+      return result
+    end
+  end
+end

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -75,6 +75,23 @@ module Uspec
       message
     end
 
+    def msg_spec_value error
+      if error.backtrace then
+        bt = error.backtrace
+      else
+        bt = caller
+      end
+
+      error_info = white bt_format bt
+
+      message = <<~MSG
+      #{error.message}
+      #{error_info}
+      MSG
+
+      error_indent error, message, header: false
+    end
+
     def msg_source_error error, desc, cli = nil
       error_info = error_context error.backtrace[4].split(?:), error.backtrace
 
@@ -90,13 +107,13 @@ module Uspec
         #{error_info}
       MSG
 
-      error_indent error, message, false
+      error_indent error, message, first_line_indent: false
     end
 
-    def error_context error_file, error_bt, skip_internal = true
+    def error_context error_file, origin, skip_internal = true
       [
         error_origin(*error_file),
-        white(bt_format(error_bt, skip_internal)),
+        white(bt_format(origin, skip_internal)),
         MSG_IF_USPEC_BUG
     ].join ?\n
     end
@@ -105,9 +122,9 @@ module Uspec
       "The origin of the error may be in file `#{error_file}` on line ##{error_line}."
     end
 
-    def error_indent error, message, first_line_indent = true
+    def error_indent error, message, first_line_indent: true, header: true
       a = message.split(newline)
-      a.unshift "\n#{hspace if first_line_indent}#{error_header error}#{newline}"
+      a.unshift "\n#{hspace if first_line_indent}#{error_header error}#{newline}" if header
       a << ""
       a.join("#{newline}#{hspace}")
     end

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -49,5 +49,27 @@ module Uspec
       cli.handle_interrupt! result.raw if cli
       return result
     end
+
+    def msg_source_error error, desc, cli = nil
+      error_file, error_line, _ = error.backtrace[4].split ?:
+
+      <<-MSG
+
+      #{error.class} : #{error.message}
+
+      Uspec detected a bug in your source code!
+
+      Calling #inspect on an object will recusively call #inspect on its instance variables and contents.
+      If one of those contained objects does not have an #inspect method you will see this message.
+      You will also get this message if your #inspect method or one of its callees raises an exception.
+      This is most likely to happen with BasicObject and its subclasses.
+
+      If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
+
+      Error may have occured in test `#{desc}` in file `#{error_file}` on line ##{error_line}.
+
+\t#{error.backtrace.join "\n\t"}
+      MSG
+    end
   end
 end

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -2,24 +2,6 @@ module Uspec
   module Errors
     module_function
 
-    def handle_internal_error error, cli = nil
-      message = <<-MSG
-      #{error.class} : #{error.message}
-
-      Uspec encountered an internal error, please report this bug: https://github.com/acook/uspec/issues/new
-
-\t#{error.backtrace.join "\n\t"}
-      MSG
-
-      result = Uspec::Result.new(message, error, true)
-
-      puts
-      warn message
-
-      cli.handle_interrupt! result.raw if cli
-      return result
-    end
-
     def handle_file_error error, path, cli = nil
       if SignalException === error || SystemExit === error then
         exit 3
@@ -39,6 +21,24 @@ module Uspec
         The origin of the error may be in file `#{error_file}` on line ##{error_line}.
 
   \t#{error.backtrace[0,3].join "\n\t"}
+      MSG
+
+      result = Uspec::Result.new(message, error, true)
+
+      puts
+      warn message
+
+      cli.handle_interrupt! result.raw if cli
+      return result
+    end
+
+    def handle_internal_error error, cli = nil
+      message = <<-MSG
+      #{error.class} : #{error.message}
+
+      Uspec encountered an internal error, please report this bug: https://github.com/acook/uspec/issues/new
+
+\t#{error.backtrace.join "\n\t"}
       MSG
 
       result = Uspec::Result.new(message, error, true)
@@ -71,5 +71,6 @@ module Uspec
 \t#{error.backtrace.join "\n\t"}
       MSG
     end
+
   end
 end

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -115,7 +115,7 @@ module Uspec
         error_origin(*error_file),
         white(bt_format(origin, skip_internal)),
         MSG_IF_USPEC_BUG
-    ].join ?\n
+      ].join ?\n
     end
 
     def error_origin error_file, error_line, *_

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -29,6 +29,7 @@ module Uspec
 
       message = <<~MSG
         Uspec encountered an internal error!
+
         #{error_info}
       MSG
 
@@ -39,7 +40,7 @@ module Uspec
       result = Uspec::Result.new(message, error, true)
 
       puts
-      warn error_indent error, message
+      warn error_format error, message, leading_newline: false
 
       cli.handle_interrupt! result.raw if cli
       result
@@ -52,7 +53,7 @@ module Uspec
         Error occured when evaluating spec `#{desc}`.
         #{error_info}
       MSG
-      body = error_indent error, info
+      body = error_format error, info, first_line_indent: false
 
       message = <<~MSG
         #{red 'Exception'}
@@ -63,14 +64,14 @@ module Uspec
     end
 
     def msg_spec_value error
-      error_info = white bt_format(bt_get error)
+      error_info = white bt_format(bt_get error).chomp
 
       message = <<~MSG
         #{error.message}
         #{error_info}
       MSG
 
-      error_indent error, message, header: false
+      error_format error, message, header: false
     end
 
     def msg_source_error error, desc, cli = nil
@@ -88,7 +89,7 @@ module Uspec
         #{error_info}
       MSG
 
-      error_indent error, message
+      error_format error, message, first_line_indent: false
     end
 
     def error_context error, skip_internal: true
@@ -109,9 +110,21 @@ module Uspec
       "The origin of the error may be in file `#{error_file}` on line ##{error_line}."
     end
 
-    def error_indent error, message, first_line_indent: true, leading_newline: true, header: true
+    def error_format error, message, first_line_indent: true, leading_newline: true, header: true
+      h = ""
+
+      if header then
+        h << newline if leading_newline
+        h << hspace if first_line_indent
+        h << error_header(error)
+        h << vspace
+      end
+
+      error_indent(error, h + message)
+    end
+
+    def error_indent error, message
       a = message.split(newline)
-      a.unshift "#{newline if leading_newline}#{hspace if first_line_indent}#{error_header error}#{newline}" if header
       a << ""
       a.join("#{newline}#{hspace}")
     end

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -11,10 +11,6 @@ module Uspec
     TRACE_EXCLUDE_PATTERN = /#{Uspec.libpath.join 'lib'}|#{Uspec.libpath.join 'bin'}/
 
     def handle_file_error error, path, cli = nil
-      if SignalException === error || SystemExit === error then
-        exit 3
-      end
-
       error_info = error_context error
 
       message = <<~MSG

--- a/lib/uspec/errors.rb
+++ b/lib/uspec/errors.rb
@@ -1,6 +1,13 @@
+require_relative "terminal"
+
 module Uspec
   module Errors
     module_function
+
+    extend Uspec::Terminal
+
+    MSG_USPEC_BUG_URL = "https://github.com/acook/uspec/issues/new"
+    MSG_IF_USPEC_BUG  = "If you think this is a bug in Uspec please report it: #{MSG_USPEC_BUG_URL}"
 
     def handle_file_error error, path, cli = nil
       if SignalException === error || SystemExit === error then
@@ -9,34 +16,34 @@ module Uspec
 
       error_file, error_line, _ = error.backtrace.first.split ?:
 
-      message = <<-MSG
+      message = <<~MSG
         #{error.class} : #{error.message}
 
         Uspec encountered an error when loading a test file.
         This is probably a typo in the test file or the file it is testing.
 
-        If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
-
         Error occured when loading test file `#{path}`.
         The origin of the error may be in file `#{error_file}` on line ##{error_line}.
 
-  \t#{error.backtrace[0,3].join "\n\t"}
+        #{bt_indent error.backtrace[0,3]}
+
+        #{MSG_IF_USPEC_BUG}
       MSG
 
       result = Uspec::Result.new(message, error, true)
 
       puts
-      warn message
+      warn error_indent message
 
       cli.handle_interrupt! result.raw if cli
-      return result
+      result
     end
 
     def handle_internal_error error, cli = nil
       message = <<-MSG
       #{error.class} : #{error.message}
 
-      Uspec encountered an internal error, please report this bug: https://github.com/acook/uspec/issues/new
+      Uspec encountered an internal error, please report this bug: #{MSG_USPEC_BUG_URL}
 
 \t#{error.backtrace.join "\n\t"}
       MSG
@@ -47,29 +54,40 @@ module Uspec
       warn message
 
       cli.handle_interrupt! result.raw if cli
-      return result
+      result
     end
 
     def msg_source_error error, desc, cli = nil
       error_file, error_line, _ = error.backtrace[4].split ?:
 
-      <<-MSG
+      message = <<~MSG
+        #{error.class} : #{error.message}
 
-      #{error.class} : #{error.message}
+        Uspec detected a bug in your source code!
 
-      Uspec detected a bug in your source code!
+        Calling #inspect on an object will recusively call #inspect on its instance variables and contents.
+        If one of those contained objects does not have an #inspect method you will see this message.
+        You will also get this message if your #inspect method or one of its callees raises an exception.
+        This is most likely to happen with BasicObject and its subclasses.
 
-      Calling #inspect on an object will recusively call #inspect on its instance variables and contents.
-      If one of those contained objects does not have an #inspect method you will see this message.
-      You will also get this message if your #inspect method or one of its callees raises an exception.
-      This is most likely to happen with BasicObject and its subclasses.
+        Error may have occured in test `#{desc}` in file `#{error_file}` on line ##{error_line}.
 
-      If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
+        #{bt_indent error.backtrace}
 
-      Error may have occured in test `#{desc}` in file `#{error_file}` on line ##{error_line}.
-
-\t#{error.backtrace.join "\n\t"}
+        #{MSG_IF_USPEC_BUG}
       MSG
+
+      error_indent message
+    end
+
+    def error_indent message
+      a = message.split(newline)
+      a[0] = "#{hspace}#{a.first}"
+      a.join("#{newline}#{hspace}")
+    end
+
+    def bt_indent bt
+      "#{hspace}" + bt.join("#{newline}#{hspace}") if bt
     end
 
   end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -58,5 +58,11 @@ module Uspec
       cli.handle_interrupt! result ? result.raw : raw_result
       return [state, error, result, raw_result]
     end
+
+    def inspect
+      <<~MSG.chomp
+        <#{self.class}##{self.object_id} @cli=#{@cli ? '<...>' : @cli} @define=#{@define ? '<...>' : @define}>
+      MSG
+    end
   end
 end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -19,6 +19,7 @@ module Uspec
       @line = line
       define.instance_eval(path.read, path.to_s)
     rescue Exception => error
+      raise error if SystemExit === error
       result = Uspec::Errors.handle_file_error error, path, cli
       stats << result if result
     end

--- a/lib/uspec/harness.rb
+++ b/lib/uspec/harness.rb
@@ -20,7 +20,6 @@ module Uspec
       define.instance_eval(path.read, path.to_s)
     rescue Exception => error
       result = Uspec::Errors.handle_file_error error, path, cli
-    ensure
       stats << result if result
     end
 

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -56,13 +56,7 @@ module Uspec
         hspace, 'in spec at ', source.first, vspace,
         hspace, red(subklassinfo), inspector, (Class === raw ? ' Class' : ''), newline
       ].join
-    rescue Exception => error
-      return handler.simple_inspector if error.message.include? handler.get_id
 
-      [
-        red('Failed'), newline,
-        Uspec::Errors.msg_source_error(error, desc),
-      ].join
     end
 
     # Attempts to inspect an object
@@ -77,6 +71,13 @@ module Uspec
       else
         handler.inspector!
       end
+    rescue Exception => error
+      return handler.simple_inspector if error.message.include? handler.get_id
+
+      [
+        red('Unable to Inspect Object'), newline,
+        Uspec::Errors.msg_source_error(error, desc),
+      ].join
     end
 
     def success?

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -27,12 +27,7 @@ module Uspec
       elsif ex == true then
         Uspec::Errors.msg_spec_error raw, desc
       else
-        [
-          red('Failed'), vspace,
-          hspace, 'Spec did not return a boolean value ', newline,
-          hspace, 'in spec at ', source.first, vspace,
-          hspace, red(subklassinfo), inspector, (Class === raw ? ' Class' : ''), newline
-        ].join
+        nonboolean
       end
     end
 
@@ -54,6 +49,22 @@ module Uspec
       end
     end
 
+    def nonboolean
+      [
+        red('Failed'), vspace,
+        hspace, 'Spec did not return a boolean value ', newline,
+        hspace, 'in spec at ', source.first, vspace,
+        hspace, red(subklassinfo), inspector, (Class === raw ? ' Class' : ''), newline
+      ].join
+    rescue Exception => error
+      return handler.simple_inspector if error.message.include? handler.get_id
+
+      [
+        red('Failed'), newline,
+        Uspec::Errors.msg_source_error(error, desc),
+      ].join
+    end
+
     # Attempts to inspect an object
     def inspector
       if String === raw && raw.include?(?\n) then
@@ -66,10 +77,6 @@ module Uspec
       else
         handler.inspector!
       end
-    rescue Exception => error
-      return handler.simple_inspector if error.message.include? handler.get_id
-
-      Uspec::Errors.msg_source_error error, desc
     end
 
     def success?

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -110,24 +110,7 @@ module Uspec
     rescue Exception => error
       return handler.simple_inspector if error.message.include? handler.get_id
 
-      error_file, error_line, _ = error.backtrace[4].split ?:
-
-      <<-MSG
-
-      #{error.class} : #{error.message}
-
-      Uspec detected a bug in your source code!
-      Calling #inspect on an object will recusively call #inspect on its instance variables and contents.
-      If one of those contained objects does not have an #inspect method you will see this message.
-      You will also get this message if your #inspect method or one of its callees raises an exception.
-      This is most likely to happen with BasicObject and its subclasses.
-
-      If you think this is a bug in Uspec please report it: https://github.com/acook/uspec/issues/new
-
-      Error may have occured in test `#{desc}` in file `#{error_file}` on line ##{error_line}.
-
-\t#{error.backtrace.join "\n\t"}
-      MSG
+      Uspec::Errors.msg_source_error error, desc
     end
 
     def success?

--- a/lib/uspec/result.rb
+++ b/lib/uspec/result.rb
@@ -62,11 +62,7 @@ module Uspec
           raw.split(newline).unshift(newline).join(PREFIX), normal, newline,
         ].join
       elsif Exception === raw then
-        [
-          raw.message, vspace,
-          white(Uspec::Errors.bt_clean raw.backtrace),
-          normal, newline,
-      ].join
+        Uspec::Errors.msg_spec_value raw
       else
         handler.inspector!
       end

--- a/uspec/cli_spec.rb
+++ b/uspec/cli_spec.rb
@@ -1,14 +1,5 @@
 require_relative 'uspec_helper'
 
-def new_cli path  = '.'
-  Uspec::CLI.new(Array(path))
-end
-
-def run_specs path
-  new_cli(path).run_specs
-end
-
-
 spec 'shows usage' do
   output = capture do
     exec 'bin/uspec -h'

--- a/uspec/dsl_spec.rb
+++ b/uspec/dsl_spec.rb
@@ -4,7 +4,7 @@ spec 'catches errors' do
   cli = new_cli
 
   output = outstr do
-    cli.harness.define.spec 'exception' do
+    cli.harness.define.spec 'exception spec' do
       raise 'test exception'
     end
   end

--- a/uspec/errors_spec.rb
+++ b/uspec/errors_spec.rb
@@ -33,5 +33,5 @@ spec 'source errors are captured' do
   result = Uspec::Result.new "source error result", a, true
   output = result.inspector
 
-  output.include?('Uspec encountered an internal error') || output
+  output.include?('Uspec detected a bug in your source') || output
 end

--- a/uspec/errors_spec.rb
+++ b/uspec/errors_spec.rb
@@ -21,3 +21,17 @@ spec 'internal errors are captured' do
 
   output.include?('Uspec encountered an internal error') || output
 end
+
+spec 'source errors are captured' do
+  bo = BasicObject.new
+  def bo.inspect
+    invalid_for_source_error
+  end
+
+  a = [ bo ]
+
+  result = Uspec::Result.new "source error result", a, true
+  output = result.inspector
+
+  output.include?('Uspec encountered an internal error') || output
+end

--- a/uspec/errors_spec.rb
+++ b/uspec/errors_spec.rb
@@ -1,0 +1,23 @@
+require_relative "uspec_helper"
+
+spec 'file errors are captured' do
+  cli = new_cli
+
+  output = outstr do
+    cli.harness.file_eval testdir.join('broken_require_spec'), nil
+  end
+
+  output.include?('Uspec encountered an error when loading') || output
+end
+
+spec 'internal errors are captured' do
+  cli = new_cli
+
+  output = outstr do
+   cli.harness.spec_eval BasicObject.new, BasicObject.new do
+      raise 'block error'
+    end
+  end
+
+  output.include?('Uspec encountered an internal error') || output
+end

--- a/uspec/result_spec.rb
+++ b/uspec/result_spec.rb
@@ -103,8 +103,12 @@ spec "handles raised exceptions without backtraces" do
 end
 
 spec "doesn't show 'run' for spec file in stack trace" do
+  Uspec::Errors.clean_backtrace!
+
   result = Uspec::Result.new "No Run Exception Trace Result", exception_value, true
   expected = /uspec.*run/
   actual =  result.pretty
+
+  Uspec::Errors.full_backtrace!
   !actual.match?(expected) || result.pretty
 end

--- a/uspec/test_specs/error_value_spec
+++ b/uspec/test_specs/error_value_spec
@@ -1,0 +1,8 @@
+class ErrorValue < StandardError
+end
+
+spec "error value spec" do
+  raise ErrorValue, "A test exception!"
+rescue ErrorValue => err
+  return err
+end

--- a/uspec/test_specs/internal_error_spec
+++ b/uspec/test_specs/internal_error_spec
@@ -1,0 +1,3 @@
+spec BasicObject.new do
+  raise 'block error'
+end

--- a/uspec/test_specs/source_error_spec
+++ b/uspec/test_specs/source_error_spec
@@ -1,0 +1,8 @@
+spec "this spec will create a source error due to a broken inspect method" do
+  bo = BasicObject.new
+  def bo.inspect
+    invalid_for_source_error
+  end
+
+  [ bo ]
+end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -9,6 +9,8 @@ require 'stringio'
 require_relative '../lib/uspec'
 extend Uspec
 
+Uspec::Errors.full_backtrace!
+
 def capture
   readme, writeme = IO.pipe
   pid = fork do

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -59,3 +59,11 @@ end
 def testdir
   specdir.join('test_specs')
 end
+
+def new_cli path  = '.'
+  Uspec::CLI.new(Array(path))
+end
+
+def run_specs path
+  new_cli(path).run_specs
+end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -1,6 +1,5 @@
 begin
-  require 'bundler'
-  Bundler.require(:test, :development)
+  require 'pry'
 rescue LoadError => err
   nil
 end

--- a/uspec/uspec_helper.rb
+++ b/uspec/uspec_helper.rb
@@ -1,5 +1,6 @@
 begin
-  require 'pry'
+  require 'bundler'
+  Bundler.require(:test, :development)
 rescue LoadError => err
   nil
 end


### PR DESCRIPTION
Uspec's error handling is perhaps its most important functionality. It handles edge cases and tries to provide useful feedback on them.

However each error contains a big block of text and is formatted slightly differently. There are a lot of similarities between many of them, so perhaps there is a better way to share functionality and be certain that everything that needs doing is done.

It also adds additional tests around each error  to prove that they work as expected.